### PR TITLE
Fix: Colons in names aren't transformed into dots

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 
-inThisBuild(List(
+inThisBuild(Seq(
   name := "prometheus-datadog-bridge",
   organization := "com.github.chris_zen",
 
@@ -28,6 +28,7 @@ lazy val root = Project(id = "prometheus-datadog-bridge", base = file("."))
   .configs(IntegrationTest)
   .settings(itSettings)
   .settings(
+    parallelExecution in Test := false,
     libraryDependencies ++= Seq(
       "org.slf4j" % "slf4j-api" % "1.7.25",
       "io.prometheus" % "simpleclient" % "0.3.0",

--- a/src/test/scala/com/github/chris_zen/prometheus/bridge/datadog/DatadogPushSpec.scala
+++ b/src/test/scala/com/github/chris_zen/prometheus/bridge/datadog/DatadogPushSpec.scala
@@ -80,6 +80,15 @@ class DatadogPushSpec extends FlatSpec with Matchers with DatadogPushFixtures {
       verifyNoMoreInteractions(client)
     }
   }
+
+  it should "translate colons in names into dots" in {
+    withDatadogPush { (registry, pusher, client) =>
+      Gauge.build("prefix:metric1", "help1").register(registry).set(1.0)
+      pusher.push()
+      verify(client).gauge("prefix.metric1", 1.0)
+      verifyNoMoreInteractions(client)
+    }
+  }
 }
 
 trait DatadogPushFixtures extends MockitoSugar {


### PR DESCRIPTION
This PR fixes a bug where colons in metric names were not translated into dots when reporting into Datadog, and then it ended discarding those metrics.