### PR TITLE
Fix counter not sent as deltas but as absolute value

### DIFF
--- a/src/it/scala/com/github/chris_zen/prometheus/bridge/datadog/DatadogBridgeItSpec.scala
+++ b/src/it/scala/com/github/chris_zen/prometheus/bridge/datadog/DatadogBridgeItSpec.scala
@@ -31,13 +31,13 @@ class DatadogBridgeItSpec extends FlatSpec with Matchers with StatsDFixtures {
 
       Thread.sleep(PeriodMillis)
 
-      statsD.receive shouldBe "prefix.metric2:2|c|#l0:v0,l2:v2,l1:v1"
+      statsD.receive shouldBe "prefix.metric2:1|c|#l0:v0,l2:v2,l1:v1"
 
       counter.labels("v1", "v2").inc(1.0)
 
       Thread.sleep(PeriodMillis)
 
-      statsD.receive shouldBe "prefix.metric2:3|c|#l0:v0,l2:v2,l1:v1"
+      statsD.receive shouldBe "prefix.metric2:1|c|#l0:v0,l2:v2,l1:v1"
 
       bridge.stop()
     }

--- a/src/test/scala/com/github/chris_zen/prometheus/bridge/datadog/DatadogPushSpec.scala
+++ b/src/test/scala/com/github/chris_zen/prometheus/bridge/datadog/DatadogPushSpec.scala
@@ -42,6 +42,20 @@ class DatadogPushSpec extends FlatSpec with Matchers with DatadogPushFixtures {
     }
   }
 
+  it should "push metrics from a counter as deltas" in {
+    withDatadogPush { (registry, pusher, client) =>
+      val metric1 = Counter.build("metric1", "help2").register(registry)
+      metric1.inc(1.0)
+      pusher.push()
+      verify(client).count("metric1", 1.0)
+      verifyNoMoreInteractions(client)
+      metric1.inc(4.0)
+      pusher.push()
+      verify(client).count("metric1", 4.0)
+      verifyNoMoreInteractions(client)
+    }
+  }
+
   it should "push metrics from a summary" in {
     withDatadogPush { (registry, pusher, client) =>
       val summary = Summary.build("metric1", "help1").quantile(0.50, 0.05).labelNames("l1").register(registry)


### PR DESCRIPTION
Datadog `.count()` was expecting a delta value for the counter, instead the absolute value was being used. This PR fixes that by keeping an internal map with the previous values and calculating the delta every time a push is done.