### PR TITLE
Ignore NaNs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val root = Project(id = "prometheus-datadog-bridge", base = file("."))
     libraryDependencies ++= Seq(
       "org.slf4j" % "slf4j-api" % "1.7.25",
       "io.prometheus" % "simpleclient" % "0.6.0",
-      "com.datadoghq" % "java-dogstatsd-client" % "2.5",
+      "com.datadoghq" % "java-dogstatsd-client" % "2.7",
 
       "org.slf4j" % "slf4j-log4j12" % "1.7.25" % Test,
       "org.scalatest" %% "scalatest" % "3.0.4" % Test,

--- a/src/test/scala/com/github/chris_zen/prometheus/bridge/datadog/DatadogPushSpec.scala
+++ b/src/test/scala/com/github/chris_zen/prometheus/bridge/datadog/DatadogPushSpec.scala
@@ -103,6 +103,14 @@ class DatadogPushSpec extends FlatSpec with Matchers with DatadogPushFixtures {
       verifyNoMoreInteractions(client)
     }
   }
+
+  it should "ignore metrics with a NaN value" in {
+    withDatadogPush { (registry, pusher, client) =>
+      Gauge.build("prefix:metric1", "help1").register(registry).set(Double.NaN)
+      pusher.push()
+      verifyNoMoreInteractions(client)
+    }
+  }
 }
 
 trait DatadogPushFixtures extends MockitoSugar {


### PR DESCRIPTION
There is a bug in old versions of the Datadog agent where the DogstatD daemon dies when it receives a metric with NaN value, rather than ignoring it according to specs.
This fix, takes care of ignoring them to avoid that problem in the cases where the agent can not be upgraded easily.